### PR TITLE
Save previous value of body overflow style - modal inception

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -24,16 +24,22 @@ class Modal extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.open) {
-      document.body.style.overflow = 'hidden';
-      this.setState({ open: true, showPortal: true });
+    if (!this.props.open && nextProps.open) {
+      this.setState({
+        open: true,
+        showPortal: true,
+        previousBodyStyleOverflow: document.body.style.overflow,
+      },
+      () => {
+        document.body.style.overflow = 'hidden';
+      });
     }
     if (this.props.open && !nextProps.open) {
       this.setState({ open: false });
       // Let the animation finish
       this.timeout = setTimeout(() => {
         this.setState({ showPortal: false });
-        document.body.style.overflow = null;
+        document.body.style.overflow = this.state.previousBodyStyleOverflow;
       }, 500);
     }
   }


### PR DESCRIPTION
Save previous value of body overflow style.

This should be more bullet proof if people have already some value in
there that is not empty.