### PR TITLE
IE 11 Fix

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -48,7 +48,7 @@ class Modal extends Component {
     if (this.props.closeOnEsc) {
       document.removeEventListener('keydown', this.handleKeydown);
     }
-    document.body.style.overflow = null;
+    document.body.style.overflow = this.state.previousBodyStyleOverflow;
     if (this.timeout) {
       clearTimeout(this.timeout);
     }


### PR DESCRIPTION
IE11 was not removing the "overflow:hidden" inline style when the user
dismissed the modal.