### PR TITLE
Fix issue with animation, also fix the IE11 issue

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -36,10 +36,10 @@ class Modal extends Component {
     }
     if (this.props.open && !nextProps.open) {
       this.setState({ open: false });
+      document.body.style.overflow = this.state.previousBodyStyleOverflow;
       // Let the animation finish
       this.timeout = setTimeout(() => {
         this.setState({ showPortal: false });
-        document.body.style.overflow = this.state.previousBodyStyleOverflow;
       }, 500);
     }
   }
@@ -48,7 +48,6 @@ class Modal extends Component {
     if (this.props.closeOnEsc) {
       document.removeEventListener('keydown', this.handleKeydown);
     }
-    document.body.style.overflow = this.state.previousBodyStyleOverflow;
     if (this.timeout) {
       clearTimeout(this.timeout);
     }


### PR DESCRIPTION
Hi, 

I found out, that there is still an issue.

When changing modals fast (some survey), then the animation is breaking the overflow reset. 
Moving it outside the "setTimeout" will fix it.

What I dont know is the resetting the overflow manually in componentWillUnmout.
I removed it and tested it in IE11 and it worked properly.
What is the exact moment it is being used?
@russellmorgan How can I simulate the IE11 issue?
