### PR TITLE
[React 15.5] Fix PropTypes warnings by using prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/pradel/react-responsive-modal#readme",
   "dependencies": {
     "classnames": "^2.2.5",
+    "prop-types": "^15.5.8",
     "react-addons-css-transition-group": "^15.4.1",
     "react-jss": "^4.2.0",
     "react-minimalist-portal": "^1.0.6"

--- a/src/modal.js
+++ b/src/modal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Portal from 'react-minimalist-portal';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import classNames from 'classnames';


### PR DESCRIPTION
Pretty straightforward fix, just added `prop-types` as a dependency, and import `PropTypes` from there instead of the `react` package.
See this post for details
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html