### PR TITLE
Change overflow property

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -40,7 +40,7 @@ class Modal extends Component {
       // Let the animation finish
       this.timeout = setTimeout(() => {
         this.setState({ showPortal: false });
-        document.body.style.overflow = this.state.previousBodyStyleOverflow;
+        document.body.style.overflow = 'initial';
       }, 500);
     }
   }
@@ -49,7 +49,7 @@ class Modal extends Component {
     if (this.props.closeOnEsc) {
       document.removeEventListener('keydown', this.handleKeydown);
     }
-    document.body.style.overflow = this.state.previousBodyStyleOverflow;
+    document.body.style.overflow = 'initial';
     if (this.timeout) {
       clearTimeout(this.timeout);
     }


### PR DESCRIPTION
I discovered that when using multiple modal consecutively  `this.state.previousBodyStyleOverflow` would sometimes be set incorrectly. 