### PR TITLE
Changed overflow to 'auto'

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -40,7 +40,7 @@ class Modal extends Component {
       // Let the animation finish
       this.timeout = setTimeout(() => {
         this.setState({ showPortal: false });
-        document.body.style.overflow = 'initial';
+        document.body.style.overflow = 'auto';
       }, 500);
     }
   }
@@ -49,7 +49,7 @@ class Modal extends Component {
     if (this.props.closeOnEsc) {
       document.removeEventListener('keydown', this.handleKeydown);
     }
-    document.body.style.overflow = 'initial';
+    document.body.style.overflow = 'auto';
     if (this.timeout) {
       clearTimeout(this.timeout);
     }

--- a/src/modal.js
+++ b/src/modal.js
@@ -40,7 +40,7 @@ class Modal extends Component {
       // Let the animation finish
       this.timeout = setTimeout(() => {
         this.setState({ showPortal: false });
-        document.body.style.overflow = this.state.previousBodyStyleOverflow;
+        document.body.style.overflow = 'initial';
       }, 500);
     }
   }
@@ -49,7 +49,7 @@ class Modal extends Component {
     if (this.props.closeOnEsc) {
       document.removeEventListener('keydown', this.handleKeydown);
     }
-    document.body.style.overflow = this.state.previousBodyStyleOverflow;
+    document.body.style.overflow = 'initial';
     if (this.timeout) {
       clearTimeout(this.timeout);
     }


### PR DESCRIPTION
When displaying consecutive modals I discovered that `document.body.style.overflow = this.state.previousBodyStyleOverflow` would sometimes return the incorrect overflow property. Using overflow = 'auto' seems to resolve this.

Note: I first tried the property'initial' which worked for all browsers except IE11 (did not test versions below that)