### PR TITLE
Fix scroll bar click when modal scrolls but page doesn't.

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -63,7 +63,7 @@ class Modal extends Component {
     this.props.onClose();
   };
 
-  isScrollBarClick = e => e.clientX >= document.documentElement.offsetWidth;
+  isScrollBarClick = e => e.clientX >= e.target.scrollWidth;
 
   handleKeydown = e => {
     if (e.keyCode === 27) {


### PR DESCRIPTION
Fix #43 when the main page doesn't scroll but the modal is taller and causes a scroll bar to appear.