### PR TITLE
fix typescript typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,4 +69,4 @@ interface Props {
 
 declare const ReactReponsiveModal: React.ComponentType<Props>;
 
-export = ReactReponsiveModal;
+export default ReactReponsiveModal;

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Modal = require('react-responsive-modal');
+import Modal from 'react-responsive-modal';
 
 const onClose = () => null;
 const open = true;


### PR DESCRIPTION
I recently discovered this fine project, but I found that the included typescript definitions are unfortunately unusable (at runtime the 'Modal' export is the entire module object, and not the specific Modal class). With these changes, I'm able to export it successfully and observe that the typings are applied correctly.

Thanks!