### PR TITLE
Make blocking scroll optional by adding props `blockScroll=true`

### DIFF
--- a/__tests__/__snapshots__/modal.js.snap
+++ b/__tests__/__snapshots__/modal.js.snap
@@ -3,6 +3,7 @@
 exports[`modal render should render the content 1`] = `
 <Modal
   animationDuration={50}
+  blockScroll={true}
   center={false}
   classNames={Object {}}
   classes={

--- a/__tests__/modal.js
+++ b/__tests__/modal.js
@@ -343,4 +343,36 @@ describe('modal', () => {
       wrapper.unmount();
     });
   });
+
+  describe('prop: blockScroll', () => {
+    let wrapper;
+
+    beforeAll(() => {
+      wrapper = mount(
+        <Modal {...defaultProps} blockScroll={false}>
+          <div>modal content</div>
+        </Modal>
+      );
+    });
+
+    afterAll(() => {
+      wrapper.unmount();
+    });
+
+    it('should not block the scroll when closed', () => {
+      expect(document.documentElement.style.overflow).toBe('');
+    });
+
+    it('should not block the scroll when opened', () => {
+      wrapper.setProps({ open: true });
+      expect(document.documentElement.style.overflow).toBe('');
+    });
+
+    it('should not block the scroll before or after animation', async () => {
+      wrapper.setProps({ open: false });
+      expect(document.documentElement.style.overflow).toBe('');
+      await wait();
+      expect(document.documentElement.style.overflow).toBe('');
+    });
+  });
 });

--- a/src/modal.js
+++ b/src/modal.js
@@ -50,13 +50,17 @@ class Modal extends Component {
 
   handleOpen = () => {
     modalManager.add(this);
-    this.blockScroll();
+    if (this.props.blockScroll) {
+      this.blockScroll();
+    }
     document.addEventListener('keydown', this.handleKeydown);
   };
 
   handleClose = () => {
     modalManager.remove(this);
-    this.unblockScroll();
+    if (this.props.blockScroll) {
+      this.unblockScroll();
+    }
     document.removeEventListener('keydown', this.handleKeydown);
   };
 
@@ -278,6 +282,10 @@ Modal.propTypes = {
    * You can specify a container prop which should be of type `Element`. The portal will be rendered inside that element. The default behavior will create a div node and render it at the at the end of document.body.
    */
   container: PropTypes.object, // eslint-disable-line
+  /**
+   * Whether to block scrolling when dialog is open
+   */
+  blockScroll: PropTypes.bool,
 };
 
 Modal.defaultProps = {
@@ -298,6 +306,7 @@ Modal.defaultProps = {
   children: null,
   center: false,
   animationDuration: 500,
+  blockScroll: true,
 };
 
 polyfill(Modal);

--- a/src/modal.js
+++ b/src/modal.js
@@ -120,7 +120,10 @@ class Modal extends Component {
     }
 
     this.setState({ showPortal: false });
-    this.unblockScroll();
+
+    if (this.props.blockScroll) {
+      this.unblockScroll();
+    }
   };
 
   unblockScroll = () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,6 +70,10 @@ interface Props {
    * The default behavior will create a div node and render it at the at the end of document.body.
    */
   container?: any;
+  /**
+   * Whether to block scrolling when dialog is open
+   */
+  blockScroll?: boolean;
 }
 
 declare const ReactReponsiveModal: React.ComponentType<Props>;


### PR DESCRIPTION
Thanks for creating this project and added the useful prop `container` in v3.1 !   

I use `container` to achieve rendering the modal within a certain container (instead of the whole viewport). In such scenario, the feature of locking scrolling for the whole page become a little unnecessary. That's why I think adding an optional prop `blockScroll` (which default to true) might be a good idea. would love to hear your thought!