### PR TITLE
Fixed centring of overlay in IE11

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2,7 +2,6 @@
   background: rgba(0, 0, 0, 0.75);
   display: flex;
   align-items: flex-start;
-  justify-content: center;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
Fixes #200 

Tested in:

Win 7 IE11
Mac OS Chrome 86, Safari 11.1.2, Firefox 60