### PR TITLE
feature: Export ModalProps

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ const classes = {
   animationOut: 'react-responsive-modal-fadeOut',
 };
 
-interface ModalProps {
+export interface ModalProps {
   /**
    * Control if the modal is open or not.
    */


### PR DESCRIPTION
Having the ModalProps exported might be useful for creating parent component that still comply with the props, without having to rewrite type for those.