### PR TITLE
fix: fix module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple responsive and accessible react modal compatible with React 16 and ready for React 17",
   "license": "MIT",
   "main": "dist/index.js",
-  "module": "dist/mylib.esm.js",
+  "module": "dist/react-responsive-modal.esm.js",
   "typings": "dist/index.d.ts",
   "scripts": {
     "start": "tsdx watch",


### PR DESCRIPTION
Currently due invalid path it is not possible to bundle this library with application code by rollup and [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve). It happens because rollup checks `module` field in `package.json`, and because path is incorrect, library is not bundled.