### PR TITLE
feat: reserveScrollBarGap option on body-scroll-lock

### DIFF
--- a/react-responsive-modal/__tests__/index.test.tsx
+++ b/react-responsive-modal/__tests__/index.test.tsx
@@ -260,6 +260,26 @@ describe('modal', () => {
       );
       expect(document.body.style.overflow).toBe('');
     });
+    it('should reserve scroll bar gap', () => {
+      const scrollBarWidth = 42;
+      const innerWidth = 500;
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: innerWidth,
+      });
+      Object.defineProperty(document.documentElement, 'clientWidth', {
+        writable: true,
+        configurable: true,
+        value: innerWidth - scrollBarWidth,
+      });
+      render(
+        <Modal open={true} onClose={() => null}>
+          <div>modal content</div>
+        </Modal>
+      );
+      expect(document.body.style.paddingRight).toBe(`${scrollBarWidth}px`);
+    });
   });
 
   describe('closeIcon', () => {

--- a/react-responsive-modal/src/useScrollLock.ts
+++ b/react-responsive-modal/src/useScrollLock.ts
@@ -12,7 +12,7 @@ export const useScrollLock = (
   useEffect(() => {
     if (open && refModal.current && blockScroll) {
       oldRef.current = refModal.current;
-      disableBodyScroll(refModal.current);
+      disableBodyScroll(refModal.current, { reserveScrollBarGap: true });
     }
     return () => {
       if (oldRef.current) {


### PR DESCRIPTION
From the body-scroll-lock README:

> If the overflow property of the body is set to hidden, the body widens by the width of the scrollbar. This produces an unpleasant flickering effect, especially on websites with centered content. If the reserveScrollBarGap option is set, this gap is filled by a padding-right on the body element.

Without reserveScrollBarGap (current behavior):
![without-reserveScrollBarGap](https://user-images.githubusercontent.com/5550247/117516067-9fa2d480-af5d-11eb-84e9-683e2f617702.gif)

With reserveScrollBarGap:
![with-reserveScrollBarGap](https://user-images.githubusercontent.com/5550247/117516087-b0ebe100-af5d-11eb-9089-ea8b7413d891.gif)